### PR TITLE
Fix: SMB/CIFS/CEPH mounted drive caused large file upload errors

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -149,7 +149,7 @@ class File extends Node implements IFile {
 			// mark file as partial while uploading (ignored by the scanner)
 			$partFilePath = $this->getPartFileBasePath($this->path) . '.ocTransferId' . rand() . '.part';
 
-			if (!$view->isCreatable($partFilePath) && $view->isUpdatable($this->path)) {
+			if ((!$view->isCreatable($partFilePath) && $view->isUpdatable($this->path)) || (!$view->isReadable($partFilePath))) {
 				$needsPartFile = false;
 			}
 		}


### PR DESCRIPTION
On some installations using ceph/smb/cifs shares the protocol does not support renaming on the fly. This causes the issue as linked. This fix added a check for this and disables part-file if needed.